### PR TITLE
Disable MySQL Binlog by default #2

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -39,7 +39,7 @@ services:
       - oitc-backend
     volumes:
       - mysql-data:/var/lib/mysql
-    command: mysqld --sql_mode="" --innodb-buffer-pool-size=256M --innodb-flush-log-at-trx-commit=2 --innodb-file-per-table=1 --innodb-flush-method=O_DIRECT --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
+    command: mysqld --sql_mode="" --innodb-buffer-pool-size=256M --innodb-flush-log-at-trx-commit=2 --innodb-file-per-table=1 --innodb-flush-method=O_DIRECT --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci --skip-log-bin
     deploy:
       restart_policy:
         condition: on-failure


### PR DESCRIPTION
This change disable the MySQL bin log by default as as suggested by #2 and which is also the default for non containerized setups of openITCOCKPIT: https://github.com/it-novum/openITCOCKPIT/blob/development/system/etc/mysql/conf.d/openitcockpit.cnf#L11

Docs: https://docs.openitcockpit.io/en/installation/docker/#mysql-binary-log